### PR TITLE
Additional spec file deps

### DIFF
--- a/dist/eol-tracker.spec
+++ b/dist/eol-tracker.spec
@@ -21,6 +21,14 @@ BuildRequires:  %{_bindir}/yarnpkg
 
 Requires:       distribution-gpg-keys
 
+# plugins that aren't found during build
+Requires:       cutelyst2-plugins
+Requires:       qt5-qtbase-postgresql
+
+# translation files
+Requires:       libCutelyst2Qt5-2-lang
+Requires:       libCutelyst2Qt5ViewGrantlee2-lang
+
 %description
 eol-tracker is an application that allows you to monitor what package versions
 different Linux distributions have available. With this new, powerful information,


### PR DESCRIPTION
These are plugin shared object packages that didn't get picked up by rpmbuild. Also the lang package to supress warnings.